### PR TITLE
[AIRFLOW-3918] add git sync ssh

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -645,7 +645,6 @@ git_subpath =
 # for SSH authentication
 git_user =
 git_password =
-git_subpath =
 git_sync_root = /git
 git_sync_dest = repo
 # Mount point of the volume if git-sync is being used.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -640,6 +640,9 @@ logs_volume_host =
 # Git credentials and repository for DAGs mounted via Git (mutually exclusive with volume claim)
 git_repo =
 git_branch =
+git_subpath =
+# Use git_user and git_password for user authentication or git_ssh_key_secret_name and git_ssh_key_secret_key
+# for SSH authentication
 git_user =
 git_password =
 git_subpath =
@@ -648,6 +651,9 @@ git_sync_dest = repo
 # Mount point of the volume if git-sync is being used.
 # i.e. {AIRFLOW_HOME}/dags
 git_dags_folder_mount_point =
+# Kubernetes secret name and secret key where the SSH key is stored
+git_ssh_key_secret_name =
+git_ssh_key_secret_key =
 
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
 git_sync_container_repository = k8s.gcr.io/git-sync

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -650,8 +650,8 @@ git_sync_dest = repo
 git_dags_folder_mount_point =
 
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
-git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
-git_sync_container_tag = v2.0.5
+git_sync_container_repository = k8s.gcr.io/git-sync
+git_sync_container_tag = v3.1.1
 git_sync_init_container_name = git-sync-clone
 
 # The name of the Kubernetes service account to be associated with airflow workers, if any.

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -163,10 +163,13 @@ class KubeConfig:
         self.git_dags_folder_mount_point = conf.get(self.kubernetes_section,
                                                     'git_dags_folder_mount_point')
 
-        # Optionally a user may supply a `git_user` and `git_password` for private
-        # repositories
+        # Optionally a user may supply a (`git_user` AND `git_password`) OR
+        # (`git_ssh_key_secret_name` AND `git_ssh_key_secret_key`) for
+        # private repositories
         self.git_user = conf.get(self.kubernetes_section, 'git_user')
         self.git_password = conf.get(self.kubernetes_section, 'git_password')
+        self.git_ssh_key_secret_name = conf.get(self.kubernetes_section, 'git_ssh_key_secret_name')
+        self.git_ssh_key_secret_key = conf.get(self.kubernetes_section, 'git_ssh_key_secret_key')
 
         # NOTE: The user may optionally use a volume claim to mount a PV containing
         # DAGs directly
@@ -251,6 +254,13 @@ class KubeConfig:
                 'or `dags_volume_host` '
                 'or `dags_in_image` '
                 'or `git_repo and git_branch and git_dags_folder_mount_point`')
+        if self.git_repo and (self.git_user or self.git_password) and (self.git_ssh_key_secret_name or self.git_ssh_key_secret_key):
+            raise AirflowConfigException(
+                'In kubernetes mode, using `git_repo` to pull the DAGs: '
+                'for private repositories, either `git_user` and `git_password` '
+                'must be set for authentication through user credentials, '
+                'or `git_ssh_key_secret_name` and git_ssh_key_secret_key '
+                'must be set for authentication through ssh key, but not both')
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -254,11 +254,13 @@ class KubeConfig:
                 'or `dags_volume_host` '
                 'or `dags_in_image` '
                 'or `git_repo and git_branch and git_dags_folder_mount_point`')
-        if self.git_repo and (self.git_user or self.git_password) and (self.git_ssh_key_secret_name or self.git_ssh_key_secret_key):
+        if self.git_repo \
+           and (self.git_user or self.git_password) \
+           and (self.git_ssh_key_secret_name or self.git_ssh_key_secret_key):
             raise AirflowConfigException(
                 'In kubernetes mode, using `git_repo` to pull the DAGs: '
                 'for private repositories, either `git_user` and `git_password` '
-                'must be set for authentication through user credentials, '
+                'must be set for authentication through user credentials; '
                 'or `git_ssh_key_secret_name` and git_ssh_key_secret_key '
                 'must be set for authentication through ssh key, but not both')
 

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -191,3 +191,8 @@ class KubernetesRequestFactory:
     def extract_tolerations(pod, req):
         if pod.tolerations:
             req['spec']['tolerations'] = pod.tolerations
+    
+    @staticmethod
+    def extract_security_context(pod, req):
+        if pod.security_context:
+            req['spec']['securityContext'] = pod.security_context

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -191,7 +191,7 @@ class KubernetesRequestFactory:
     def extract_tolerations(pod, req):
         if pod.tolerations:
             req['spec']['tolerations'] = pod.tolerations
-    
+
     @staticmethod
     def extract_security_context(pod, req):
         if pod.security_context:

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -62,6 +62,7 @@ spec:
         self.extract_affinity(pod, req)
         self.extract_hostnetwork(pod, req)
         self.extract_tolerations(pod, req)
+        self.extract_security_context(pod, req)
         return req
 
 

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -64,6 +64,8 @@ class Pod:
     :type hostnetwork: bool
     :param tolerations: A list of kubernetes tolerations
     :type tolerations: list
+    :param security_context: A dict containing the security context for the pod
+    :type security_context: dict
     """
     def __init__(
             self,
@@ -88,6 +90,7 @@ class Pod:
             affinity=None,
             hostnetwork=False,
             tolerations=None,
+            security_context=None,
     ):
         self.image = image
         self.envs = envs or {}
@@ -110,3 +113,4 @@ class Pod:
         self.affinity = affinity or {}
         self.hostnetwork = hostnetwork or False
         self.tolerations = tolerations or []
+        self.security_context = security_context

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -302,6 +302,6 @@ class WorkerConfiguration(LoggingMixin):
             node_selectors=(kube_executor_config.node_selectors or
                             self.kube_config.kube_node_selectors),
             affinity=affinity,
-            tolerations=tolerations
+            tolerations=tolerations,
             security_context=self._get_security_context(),
         )

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -256,9 +256,8 @@ class WorkerConfiguration(LoggingMixin):
 
     def make_pod(self, namespace, worker_uuid, pod_id, dag_id, task_id, execution_date,
                  try_number, airflow_command, kube_executor_config):
-        dags_volume_name = 'airflow-dags'
-        volumes, volume_mounts = self.init_volumes_and_mounts(dags_volume_name)
-        worker_init_container_spec = self._get_init_containers(dags_volume_name)
+        volumes, volume_mounts = self.init_volumes_and_mounts()
+        worker_init_container_spec = self._get_init_containers()
         resources = Resources(
             request_memory=kube_executor_config.request_memory,
             request_cpu=kube_executor_config.request_cpu,

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -25,15 +25,20 @@ import mock
 import re
 import string
 import random
+from os import path
 from urllib3 import HTTPResponse
 from datetime import datetime
 
 try:
     from kubernetes.client.rest import ApiException
+    from airflow import configuration
+    from airflow.configuration import conf
     from airflow.contrib.executors.kubernetes_executor import AirflowKubernetesScheduler
     from airflow.contrib.executors.kubernetes_executor import KubernetesExecutor
+    from airflow.contrib.executors.kubernetes_executor import KubeConfig
     from airflow.contrib.executors.kubernetes_executor import KubernetesExecutorConfig
     from airflow.contrib.kubernetes.worker_configuration import WorkerConfiguration
+    from airflow.exceptions import AirflowConfigException
 except ImportError:
     AirflowKubernetesScheduler = None
 
@@ -161,6 +166,39 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                     "subPath shouldn't be defined"
                 )
 
+    @mock.patch.object(conf, 'get')
+    @mock.patch.object(configuration, 'as_dict')
+    def test_worker_configuration_auth_both_ssh_and_user(self, mock_config_as_dict, mock_conf_get):
+        def get_conf(*args, **kwargs):
+            if(args[0] == 'core'):
+                return '1'
+            if(args[0] == 'kubernetes'):
+                if(args[1] == 'airflow_configmap'):
+                    return 'airflow-configmap'
+                if(args[1] == 'git_ssh_key_secret_name'):
+                    return 'airflow-secrets'
+                if(args[1] == 'git_ssh_key_secret_key'):
+                    return 'gitSshKey'
+                if(args[1] == 'git_user'):
+                    return 'some-user'
+                if(args[1] == 'git_password'):
+                    return 'some-password'
+                if(args[1] == 'git_repo'):
+                    return 'git@github.com:apache/airflow.git'
+                if(args[1] == 'git_branch'):
+                    return 'master'
+                if(args[1] == 'git_dags_folder_mount_point'):
+                    return '/usr/local/airflow/dags'
+                if(args[1] == 'delete_worker_pods'):
+                    return True
+                return '1'
+            return None
+
+        mock_conf_get.side_effect = get_conf
+        mock_config_as_dict.return_value = {'core': ''}
+        with self.assertRaises(AirflowConfigException):
+            KubeConfig()
+
     def test_worker_with_subpaths(self):
         self.kube_config.dags_volume_subpath = 'dags'
         self.kube_config.logs_volume_subpath = 'logs'
@@ -236,6 +274,62 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
         self.assertEqual(dags_folder, env['AIRFLOW__CORE__DAGS_FOLDER'])
 
+    def test_init_environment_using_git_sync_ssh(self):
+        # Tests the init environment created with git-sync SSH authentication option is correct
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
+        self.kube_config.git_ssh_key_secret_key = 'gitSshKey'
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        init_containers = worker_config._get_init_containers()
+
+        self.assertTrue(init_containers)  # check not empty
+        env = init_containers[0]['env']
+
+        self.assertTrue({'name': 'GIT_SSH_KEY_FILE', 'value': '/etc/git-secret/ssh'} in env)
+        self.assertTrue({'name': 'GIT_KNOWN_HOSTS', 'value': 'false'} in env)
+        self.assertTrue({'name': 'GIT_SYNC_SSH', 'value': 'true'} in env)
+
+    def test_make_pod_git_sync_ssh(self):
+        # Tests the pod created with git-sync SSH authentication option is correct
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
+        self.kube_config.git_ssh_key_secret_key = 'gitSshKey'
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+        self.kube_config.git_sync_ssh_secret_volume_name = 'dags-repo-secret'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        kube_executor_config = KubernetesExecutorConfig(annotations=[],
+                                                        volumes=[],
+                                                        volume_mounts=[])
+
+        pod = worker_config.make_pod("default", str(uuid.uuid4()), "test_pod_id", "test_dag_id",
+                                     "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'",
+                                     kube_executor_config)
+        pod_git_sync_secret_volume = next((x for x in pod.volumes
+                                          if x['name'] == self.kube_config.git_sync_ssh_secret_volume_name),
+                                          None)
+
+        init_containers = worker_config._get_init_containers()
+        git_ssh_key_file = next((x['value'] for x in init_containers[0]['env']
+                                if x['name'] == 'GIT_SSH_KEY_FILE'), None)
+        volume_mount_ssh_key = next((x['mountPath'] for x in init_containers[0]['volumeMounts']
+                                    if x['name'] == self.kube_config.git_sync_ssh_secret_volume_name),
+                                    None)
+        self.assertTrue(git_ssh_key_file)
+        self.assertTrue(volume_mount_ssh_key)
+        self.assertEqual({'fsGroup': 65533}, pod.security_context)
+        self.assertEqual(git_ssh_key_file,
+                         path.join(volume_mount_ssh_key,
+                                   pod_git_sync_secret_volume['secret']['items'][0]['path']),
+                         ('The location where the git ssh secret is mounted'
+                          ' needs to be the same as the GIT_SSH_KEY_FILE path'))
+
     def test_make_pod_with_empty_executor_config(self):
         self.kube_config.kube_affinity = self.affinity_config
         self.kube_config.kube_tolerations = self.tolerations_config
@@ -292,7 +386,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         worker_config = WorkerConfiguration(self.kube_config)
         volumes, volume_mounts = worker_config.init_volumes_and_mounts()
 
-        init_containers = worker_config._get_init_containers(volume_mounts)
+        init_containers = worker_config._get_init_containers()
 
         dag_volume = [volume for volume in volumes.values() if volume['name'] == 'airflow-dags']
         dag_volume_mount = [mount for mount in volume_mounts.values() if mount['name'] == 'airflow-dags']
@@ -327,7 +421,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.assertEqual(self.kube_config.git_dags_folder_mount_point, dag_volume_mount[0]['mountPath'])
         self.assertTrue(dag_volume_mount[0]['readOnly'])
 
-        init_container = worker_config._get_init_containers(volume_mounts)[0]
+        init_container = worker_config._get_init_containers()[0]
         init_container_volume_mount = [mount for mount in init_container['volumeMounts']
                                        if mount['name'] == 'airflow-dags']
 
@@ -346,7 +440,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         dag_volume = [volume for volume in volumes.values() if volume['name'] == 'airflow-dags']
         dag_volume_mount = [mount for mount in volume_mounts.values() if mount['name'] == 'airflow-dags']
 
-        init_containers = worker_config._get_init_containers(volume_mounts)
+        init_containers = worker_config._get_init_containers()
 
         self.assertEqual(0, len(dag_volume))
         self.assertEqual(0, len(dag_volume_mount))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

> - [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
>  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
>  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

https://issues.apache.org/jira/browse/AIRFLOW-3918

### Description

> - [X] Here are some details about my PR, including screenshots of any UI changes:

This PR adds support for Git Sync authentication through SSH key (e.g. a GitHub deployment read-only key)

### Tests

> - [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

There is no testing in place for pulling DAGs from GitHub with the current functionality.

Possibly, in order to write such a test I could use a read-only SSH deployment key for the Airflow repository, write a Kubernetes secret for the Minikube that adds this SSH read-only key base64 encoded, and use Environment variables to configure SSH auth

For testing I've been running it on the cluster at work

### Commits

> - [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
>  1. Subject is separated from body by a blank line
>  1. Subject is limited to 50 characters (not including Jira issue reference)
>  1. Subject does not end with a period
>  1. Subject uses the imperative mood ("add", not "adding")
>  1. Body wraps at 72 characters
>  1. Body explains "what" and "why", not "how"

### Documentation

> - [X] In case of new functionality, my PR adds documentation that describes how to use it.
>  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
>  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

> - [X] Passes `flake8`

